### PR TITLE
Fix realtime voice audio format

### DIFF
--- a/dashboard/public/script.js
+++ b/dashboard/public/script.js
@@ -390,7 +390,7 @@ class GT7Dashboard {
         try {
             this.audioStream = await navigator.mediaDevices.getUserMedia({
                 audio: {
-                    sampleRate: 24000,
+                    sampleRate: 16000,
                     channelCount: 1,
                     echoCancellation: true,
                     noiseSuppression: true
@@ -399,7 +399,7 @@ class GT7Dashboard {
             
             // Create audio context for processing
             this.audioContext = new (window.AudioContext || window.webkitAudioContext)({
-                sampleRate: 24000
+                sampleRate: 16000
             });
             
             console.log('🎤 Microphone access granted');
@@ -610,8 +610,8 @@ class GT7Dashboard {
     }
     
     convertToPCM16(audioBuffer) {
-        // Resample to 24kHz if needed (OpenAI requirement)
-        const targetSampleRate = 24000;
+        // Resample to 16kHz for OpenAI realtime
+        const targetSampleRate = 16000;
         let processedBuffer = audioBuffer;
         
         if (audioBuffer.sampleRate !== targetSampleRate) {
@@ -726,7 +726,7 @@ class GT7Dashboard {
             throw new Error('No audio samples to process');
         }
         
-        const audioBuffer = this.audioContext.createBuffer(1, samples, 24000);
+        const audioBuffer = this.audioContext.createBuffer(1, samples, 16000);
         const channelData = audioBuffer.getChannelData(0);
         
         for (let i = 0; i < samples; i++) {

--- a/dashboard/racing-engineer.js
+++ b/dashboard/racing-engineer.js
@@ -76,8 +76,14 @@ class RacingEngineer extends EventEmitter {
                 modalities: ['text', 'audio'],
                 instructions: this.getEngineerInstructions(),
                 voice: this.voice,
-                input_audio_format: 'pcm16',
-                output_audio_format: 'pcm16',
+                input_audio_format: {
+                    type: 'pcm16',
+                    sample_rate: 16000
+                },
+                output_audio_format: {
+                    type: 'pcm16',
+                    sample_rate: 24000
+                },
                 input_audio_transcription: {
                     model: 'whisper-1'
                 },


### PR DESCRIPTION
## Summary
- send explicit sample rate when creating realtime voice session
- record and process audio at 16 kHz

## Testing
- `npm install --silent`
- `npm start` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_686c3b2d7a648323acc298e645c835f0