### PR TITLE
Fix audio toggle and pass telemetry to realtime API

### DIFF
--- a/dashboard/public/script.js
+++ b/dashboard/public/script.js
@@ -543,8 +543,6 @@ class GT7Dashboard {
             this.playbackContext = null;
         }
 
-        // Disconnect racing engineer session
-        this.socket.emit('engineer:disconnect');
     }
     
     resetTalkButton() {

--- a/dashboard/racing-engineer.js
+++ b/dashboard/racing-engineer.js
@@ -86,7 +86,7 @@ class RacingEngineer extends EventEmitter {
                     threshold: 0.5,
                     prefix_padding_ms: 300,
                     silence_duration_ms: 500,
-                    create_response: true
+                    create_response: false
                 },
                 temperature: 0.8,
                 max_response_output_tokens: 1000
@@ -332,6 +332,10 @@ Driver question: ${userText}`;
             case 'conversation.item.input_audio_transcription.completed':
                 console.log('🏁 Driver transcription:', message.transcript);
                 this.emit('transcription', message.transcript);
+
+                // Send the transcribed text as a user message with telemetry
+                // context and trigger a response from the engineer
+                this.sendTextMessage(message.transcript);
                 break;
                 
             case 'input_audio_buffer.speech_started':


### PR DESCRIPTION
## Summary
- allow repeated talking by keeping engineer session active when the mic stops
- update the realtime session config
- send transcribed audio to OpenAI along with latest telemetry

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c47d639fc832389c07c72606f8265